### PR TITLE
modified Afterburner-Volcano retraction on Voron presets

### DIFF
--- a/Voron.ini
+++ b/Voron.ini
@@ -414,25 +414,25 @@ inherits = *Voron_v2_250_aferburner*; *0.6nozzle*
 inherits = *Voron_v2_250_aferburner*; *0.8nozzle*
 
 [printer:Voron_v2_250_afterburner 0.6 volcano]
-inherits = *Voron_v2_250_aferburner*; *0.6nozzle*; *volcano*
+inherits = *Voron_v2_250_aferburner*; *0.6nozzle*
 printer_variant = volcano 0.6
 printer_notes = Unoffical profile, for now.\nVOLCANO
 default_filament_profile = Basic PLA VOLCANO @VORON
 
 [printer:Voron_v2_250_afterburner 0.8 volcano]
-inherits = *Voron_v2_250_aferburner*; *0.8nozzle*; *volcano*
+inherits = *Voron_v2_250_aferburner*; *0.8nozzle*
 printer_variant = volcano 0.8
 printer_notes = Unoffical profile, for now.\nVOLCANO
 default_filament_profile = Basic PLA VOLCANO @VORON
 
 [printer:Voron_v2_250_afterburner 1.0 volcano]
-inherits = *Voron_v2_250_aferburner*; *1.0nozzle*; *volcano*
+inherits = *Voron_v2_250_aferburner*; *1.0nozzle*
 printer_variant = volcano 1.0
 printer_notes = Unoffical profile, for now.\nVOLCANO
 default_filament_profile = Basic PLA VOLCANO @VORON
 
 [printer:Voron_v2_250_afterburner 1.2 volcano]
-inherits = *Voron_v2_250_aferburner*; *1.2nozzle*; *volcano*
+inherits = *Voron_v2_250_aferburner*; *1.2nozzle*
 printer_variant = volcano 1.2
 printer_notes = Unoffical profile, for now.\nVOLCANO
 default_filament_profile = Basic PLA VOLCANO @VORON
@@ -456,25 +456,25 @@ inherits = *Voron_v2_300_aferburner*; *0.6nozzle*
 inherits = *Voron_v2_300_aferburner*; *0.8nozzle*
 
 [printer:Voron_v2_300_afterburner 0.6 volcano]
-inherits = *Voron_v2_300_aferburner*; *0.6nozzle*; *volcano*
+inherits = *Voron_v2_300_aferburner*; *0.6nozzle*
 printer_variant = volcano 0.6
 printer_notes = Unoffical profile, for now.\nVOLCANO
 default_filament_profile = Basic PLA VOLCANO @VORON
 
 [printer:Voron_v2_300_afterburner 0.8 volcano]
-inherits = *Voron_v2_300_aferburner*; *0.8nozzle*; *volcano*
+inherits = *Voron_v2_300_aferburner*; *0.8nozzle*
 printer_variant = volcano 0.8
 printer_notes = Unoffical profile, for now.\nVOLCANO
 default_filament_profile = Basic PLA VOLCANO @VORON
 
 [printer:Voron_v2_300_afterburner 1.0 volcano]
-inherits = *Voron_v2_300_aferburner*; *1.0nozzle*; *volcano*
+inherits = *Voron_v2_300_aferburner*; *1.0nozzle*
 printer_variant = volcano 1.0
 printer_notes = Unoffical profile, for now.\nVOLCANO
 default_filament_profile = Basic PLA VOLCANO @VORON
 
 [printer:Voron_v2_300_afterburner 1.2 volcano]
-inherits = *Voron_v2_300_aferburner*; *1.2nozzle*; *volcano*
+inherits = *Voron_v2_300_aferburner*; *1.2nozzle*
 printer_variant = volcano 1.2
 printer_notes = Unoffical profile, for now.\nVOLCANO
 default_filament_profile = Basic PLA VOLCANO @VORON
@@ -498,25 +498,25 @@ inherits = *Voron_v2_350_aferburner*; *0.6nozzle*
 inherits = *Voron_v2_350_aferburner*; *0.8nozzle*
 
 [printer:Voron_v2_350_afterburner volcano 0.6 nozzle]
-inherits = *Voron_v2_350_aferburner*; *0.6nozzle*; *volcano*
+inherits = *Voron_v2_350_aferburner*; *0.6nozzle*
 printer_variant = volcano 0.6
 printer_notes = Unoffical profile, for now.\nVOLCANO
 default_filament_profile = Basic PLA VOLCANO @VORON
 
 [printer:Voron_v2_350_afterburner volcano 0.8 nozzle]
-inherits = *Voron_v2_350_aferburner*; *0.8nozzle*; *volcano*
+inherits = *Voron_v2_350_aferburner*; *0.8nozzle*
 printer_variant = volcano 0.8
 printer_notes = Unoffical profile, for now.\nVOLCANO
 default_filament_profile = Basic PLA VOLCANO @VORON
 
 [printer:Voron_v2_350_afterburner volcano 1.0 nozzle]
-inherits = *Voron_v2_350_aferburner*; *1.0nozzle*; *volcano*
+inherits = *Voron_v2_350_aferburner*; *1.0nozzle*
 printer_variant = volcano 1.0
 printer_notes = Unoffical profile, for now.\nVOLCANO
 default_filament_profile = Basic PLA VOLCANO @VORON
 
 [printer:Voron_v2_350_afterburner volcano 1.2 nozzle]
-inherits = *Voron_v2_350_aferburner*; *1.2nozzle*; *volcano*
+inherits = *Voron_v2_350_aferburner*; *1.2nozzle*
 printer_variant = volcano 1.2
 printer_notes = Unoffical profile, for now.\nVOLCANO
 default_filament_profile = Basic PLA VOLCANO @VORON


### PR DESCRIPTION
Per issue #4 

I simply removed the `inherits: *volcano*` flag from all direct-drive Voron presets. There might be a better way to do this!