### PR TITLE
RatRig: Optimise SQV (Jerk) for feature type

### DIFF
--- a/RatRig.ini
+++ b/RatRig.ini
@@ -406,6 +406,7 @@ deretract_speed = 40
 end_gcode = END_PRINT\n
 extra_loading_move = -2
 extruder_colour = ""
+feature_gcode = ; once we start printing infill, increase square corner velocity to 10\n{if extrusion_role=="InternalInfill"}SET_VELOCITY_LIMIT SQUARE_CORNER_VELOCITY=10 {endif}\n; when we switch to other features, go back to 5\n{if extrusion_role!="InternalInfill"}SET_VELOCITY_LIMIT SQUARE_CORNER_VELOCITY=5 {endif}
 gcode_flavor = klipper
 high_current_on_filament_swap = 0
 layer_gcode = ;AFTER_LAYER_CHANGE\n;[layer_z]\n


### PR DESCRIPTION
Run Square Corner Velocity at 5 unless we print infill or gap fill, in which case we print at an SQV of 10.