### PR TITLE
Update Voron switchwire afterburner profile to link default filaments

### DIFF
--- a/Voron.ini
+++ b/Voron.ini
@@ -335,7 +335,7 @@ printer_notes = Unoffical profile.\nPRINTER_HAS_BOWDEN\nSTU
 [printer:*Voron_Switchwire_afterburner*]
 inherits = *Voron_Switchwire*; *afterburner*
 printer_model = Voron_Switchwire_afterburner
-printer_notes = Unoffical profile.\nSTU
+printer_notes = Unoffical profile.\nSTU\nE3DV6
 
 [printer:Voron_v2_250 0.25 nozzle]
 inherits = *Voron_v2_250*; *0.25nozzle*


### PR DESCRIPTION
The printer notes needs to have the E3DV6 keyword to trigger linking the various filament profiles. I tested this locally with my copy of SuperSlicer.